### PR TITLE
Fix prologue elements order

### DIFF
--- a/src/prometheus_format.erl
+++ b/src/prometheus_format.erl
@@ -58,7 +58,7 @@ combine_lines(L1, L2) when is_binary(L1), is_binary(L2) ->
 
 emit_prologue(Type, Name) when is_binary(Type) ->
     Help = <<"# HELP ", Name/binary>>,
-    Type1 = <<"# TYPE ", Type/binary, " ", Name/binary>>,
+    Type1 = <<"# TYPE ", Name/binary, " ", Type/binary>>,
     combine_lines(Help, Type1).
 
 emit_series(Name, Labels, Value) when is_binary(Name) ->


### PR DESCRIPTION
> If the token is TYPE, exactly two more tokens are expected. The first is the metric name, and the second is either counter, gauge, histogram, summary, or untyped, defining the type for the metric of that name. 

[prometheus docs](https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-details)
